### PR TITLE
use root@localhost as default E-mail address

### DIFF
--- a/mydumper.sh
+++ b/mydumper.sh
@@ -24,7 +24,7 @@ numberThreads=4
 weekly=4
 daily=7
 ######
-email="daniel.guzman.burgos@percona.com"
+email="root@localhost"
 
 # Function definitions
 

--- a/mysqldump.sh
+++ b/mysqldump.sh
@@ -21,7 +21,7 @@ backupPath="/root/backups/$(date +%Y%m%d)/"
 weekly=4
 daily=7
 ######
-email="daniel.guzman.burgos@percona.com"
+email="root@localhost"
 
 # Function definitions
 

--- a/pull_binlog.sh
+++ b/pull_binlog.sh
@@ -21,7 +21,7 @@ remoteHost=localhost
 binPrefix="mysql-bin"
 backupPath="/root/backups"
 respawn=3 # How many attempts to restart the mysqlbinlog process try
-email="daniel.guzman.burgos@percona.com"
+email="root@localhost"
 
 # Function definitions
 

--- a/xtrabackup.sh
+++ b/xtrabackup.sh
@@ -20,7 +20,7 @@ backupPath="/root/backups/xtrabackup/$(date +%Y%m%d%H%M%S)/"
 weekly=4
 daily=7
 ######
-email="daniel.guzman.burgos@percona.com"
+email="root@localhost"
 
 # Function definitions
 


### PR DESCRIPTION
For general use of the script, it makes sense to have root@localhost
as the default E-mail address.
This to avoid that the author gets E-mails from every system that uses
this script and forgets to change the E-mail address.